### PR TITLE
Allow for fully managed isLoading parameter

### DIFF
--- a/RefreshableWrapper.js
+++ b/RefreshableWrapper.js
@@ -20,6 +20,7 @@ import Animated, {
 } from 'react-native-reanimated';
 
 const RefreshableWrapper = ({
+	managedLoading = false,
 	isLoading,
 	onRefresh,
 	refreshHeight = 100,
@@ -46,6 +47,12 @@ const RefreshableWrapper = ({
 			loaderOffsetY.value = withTiming(0);
 			isRefreshing.value = false;
 			isLoaderActive.value = false;
+		} else if (managedLoading) {
+			// In managed mode, we want to start the animation
+			// running when isLoading is set to true as well
+			loaderOffsetY.value = withTiming(refreshHeight);
+			isRefreshing.value = true;
+			isLoaderActive.value = true;
 		}
 	}, [isLoading]);
 

--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
 	"author": "4twiggers",
 	"license": "ISC",
 	"dependencies": {
-		"prop-types": "^15.7.2",
-		"lottie-react-native": "^4.0.2"
+		"prop-types": "^15.7.2"
 	},
 	"peerDependencies": {
 		"react": "*",
 		"react-native": "*",
 		"react-native-gesture-handler": "^1.10.2",
-		"react-native-reanimated": "^2.2.0"
+		"react-native-reanimated": "^2.2.0",
+		"lottie-react-native": "^4.0.2"
 	
 	}
 }


### PR DESCRIPTION
This PR enables a new optional prop to make isLoading fully managed, i.e. setting it true will cause the loading animation to start (today setting it to false causes the animation to stop, but not the other way around).  

This allows a pull to refresh animation to be triggered by an external property change as well.  In testing it seems to behave as expected, for those that desire this behavior.