### PR TITLE
Add new prop to control for full management of the isLoading

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ interface Props {
   children: JSX.Element;
   Loader?: () => JSX.Element | JSX.Element;
   bounces?: boolean;
+  managedLoading?: boolean;
 }
 
 const RefreshableWrapper: React.FC<Props> = ({
@@ -34,6 +35,7 @@ const RefreshableWrapper: React.FC<Props> = ({
   children,
   Loader = <DefaultLoader />,
   bounces = true,
+  managedLoading = false,
 }) => {
   const isRefreshing = useSharedValue(false);
   const loaderOffsetY = useSharedValue(0);
@@ -45,6 +47,12 @@ const RefreshableWrapper: React.FC<Props> = ({
       loaderOffsetY.value = withTiming(0);
       isRefreshing.value = false;
       isLoaderActive.value = false;
+    } else if (managedLoading) {
+      // In managed mode, we want to start the animation
+      // running when isLoading is set to true as well
+      loaderOffsetY.value = withTiming(refreshHeight);
+      isRefreshing.value = true;
+      isLoaderActive.value = true;
     }
   }, [isLoading]);
 


### PR DESCRIPTION
This PR enables a new optional prop to make isLoading fully managed, i.e. setting it true will cause the loading animation to start (today setting it to false causes the animation to stop, but not the other way around).

This allows a pull to refresh animation to be triggered by an external property change as well. In testing it seems to behave as expected, for those that desire this behavior.